### PR TITLE
Summer input restrictions

### DIFF
--- a/src/main/java/codeu/controller/ConversationServlet.java
+++ b/src/main/java/codeu/controller/ConversationServlet.java
@@ -105,6 +105,12 @@ public class ConversationServlet extends HttpServlet {
       request.getRequestDispatcher("/WEB-INF/view/conversations.jsp").forward(request, response);
       return;
     }
+    
+    if (conversationTitle.length()==0) {
+        request.setAttribute("error", "Conversation name cannot be empty");
+        request.getRequestDispatcher("/WEB-INF/view/conversations.jsp").forward(request, response);
+        return;
+      }
 
     if (conversationStore.isTitleTaken(conversationTitle)) {
       // conversation title is already taken, just go into that conversation instead of creating a

--- a/src/main/java/codeu/controller/RegisterServlet.java
+++ b/src/main/java/codeu/controller/RegisterServlet.java
@@ -60,8 +60,15 @@ public class RegisterServlet extends HttpServlet {
       request.getRequestDispatcher("/WEB-INF/view/register.jsp").forward(request, response);
       return;
     }
-
+    
     String password = request.getParameter("password");
+    
+    if (username.length()==0 || password.length()==0) {
+    	request.setAttribute("error", "The username and password cannot be empty");
+        request.getRequestDispatcher("/WEB-INF/view/register.jsp").forward(request, response);
+        return;
+    }
+
     String hashedPassword = BCrypt.hashpw(password, BCrypt.gensalt());
     String aboutMe = request.getParameter("aboutMe");
 

--- a/src/main/java/codeu/controller/RegisterServlet.java
+++ b/src/main/java/codeu/controller/RegisterServlet.java
@@ -54,19 +54,19 @@ public class RegisterServlet extends HttpServlet {
       request.getRequestDispatcher("/WEB-INF/view/register.jsp").forward(request, response);
       return;
     }
+    
+    String password = request.getParameter("password");
+    
+    if (username.length()==0 || password.length()==0) {
+    	request.setAttribute("error", "You must enter a username and password");
+        request.getRequestDispatcher("/WEB-INF/view/register.jsp").forward(request, response);
+        return;
+    }
 
     if (userStore.isUserRegistered(username)) {
       request.setAttribute("error", "That username is already taken.");
       request.getRequestDispatcher("/WEB-INF/view/register.jsp").forward(request, response);
       return;
-    }
-    
-    String password = request.getParameter("password");
-    
-    if (username.length()==0 || password.length()==0) {
-    	request.setAttribute("error", "The username and password cannot be empty");
-        request.getRequestDispatcher("/WEB-INF/view/register.jsp").forward(request, response);
-        return;
     }
 
     String hashedPassword = BCrypt.hashpw(password, BCrypt.gensalt());

--- a/src/test/java/codeu/controller/ConversationServletTest.java
+++ b/src/test/java/codeu/controller/ConversationServletTest.java
@@ -120,6 +120,27 @@ public class ConversationServletTest {
     Mockito.verify(mockRequest).setAttribute("error", "Please enter only letters and numbers.");
     Mockito.verify(mockRequestDispatcher).forward(mockRequest, mockResponse);
   }
+  
+  @Test
+  public void testDoPost_NullConversationName() throws IOException, ServletException {
+    Mockito.when(mockRequest.getParameter("conversationTitle")).thenReturn("");
+    Mockito.when(mockSession.getAttribute("user")).thenReturn("test_username");
+
+    User fakeUser =
+        new User(
+            UUID.randomUUID(),
+            "test_username",
+            "$2a$10$eDhncK/4cNH2KE.Y51AWpeL8/5znNBQLuAFlyJpSYNODR/SJQ/Fg6",
+            Instant.now(), "test_aboutMe");
+    Mockito.when(mockUserStore.getUser("test_username")).thenReturn(fakeUser);
+
+    conversationServlet.doPost(mockRequest, mockResponse);
+
+    Mockito.verify(mockConversationStore, Mockito.never())
+        .addConversation(Mockito.any(Conversation.class));
+    Mockito.verify(mockRequest).setAttribute("error", "Conversation name cannot be empty");
+    Mockito.verify(mockRequestDispatcher).forward(mockRequest, mockResponse);
+  }
 
   @Test
   public void testDoPost_ConversationNameTaken() throws IOException, ServletException {

--- a/src/test/java/codeu/controller/RegisterServletTest.java
+++ b/src/test/java/codeu/controller/RegisterServletTest.java
@@ -51,6 +51,30 @@ public class RegisterServletTest {
         .setAttribute("error", "Please enter only letters, numbers, and spaces.");
     Mockito.verify(mockRequestDispatcher).forward(mockRequest, mockResponse);
   }
+  
+  @Test
+  public void testDoPost_NullUsername() throws IOException, ServletException {
+    Mockito.when(mockRequest.getParameter("username")).thenReturn("");
+    Mockito.when(mockRequest.getParameter("password")).thenReturn("test password");
+
+    registerServlet.doPost(mockRequest, mockResponse);
+
+    Mockito.verify(mockRequest)
+        .setAttribute("error", "You must enter a username and password");
+    Mockito.verify(mockRequestDispatcher).forward(mockRequest, mockResponse);
+  }
+  
+  @Test
+  public void testDoPost_NullPassword() throws IOException, ServletException {
+    Mockito.when(mockRequest.getParameter("password")).thenReturn("");
+    Mockito.when(mockRequest.getParameter("username")).thenReturn("test username");
+
+    registerServlet.doPost(mockRequest, mockResponse);
+
+    Mockito.verify(mockRequest)
+        .setAttribute("error", "You must enter a username and password");
+    Mockito.verify(mockRequestDispatcher).forward(mockRequest, mockResponse);
+  }
 
   @Test
   public void testDoPost_NewUser() throws IOException, ServletException {
@@ -77,6 +101,8 @@ public class RegisterServletTest {
   @Test
   public void testDoPost_ExistingUser() throws IOException, ServletException {
     Mockito.when(mockRequest.getParameter("username")).thenReturn("test username");
+    Mockito.when(mockRequest.getParameter("password")).thenReturn("test password");
+
 
     UserStore mockUserStore = Mockito.mock(UserStore.class);
     Mockito.when(mockUserStore.isUserRegistered("test username")).thenReturn(true);


### PR DESCRIPTION
This restricts the text boxes so that they must be nonempty when you submit, which happens both on the registration page and the conversation page