### PR TITLE
Summer Open Activity Feed

### DIFF
--- a/src/main/java/codeu/controller/ActivityfeedServlet.java
+++ b/src/main/java/codeu/controller/ActivityfeedServlet.java
@@ -59,7 +59,7 @@ public class ActivityfeedServlet extends HttpServlet{
 	private List<Activity> buildList() {
 		List<Activity> activity = new ArrayList<>();
 		List<User> users = userStore.getAllUsers();
-		List<Conversation> conversations = conversationStore.getAllConversations();
+		List<Conversation> conversations = conversationStore.getAllPublicConversations();
 		List<Message> messages = messageStore.getAllMessages();
 		// adds users individually to avoid casting with generics issue
 		for (User user : users) {
@@ -74,7 +74,9 @@ public class ActivityfeedServlet extends HttpServlet{
 			User author = userStore.getUser(message.getAuthorId());
 			Conversation conversation = conversationStore.getConversationWithID(message.getConversationId());
 			message.setDisplayText(author.getName() + " sent message: \"" + message.getContent() + "\"" + " to conversation: " + conversation.getTitle());
-			activity.add(message);
+			if (conversation.getIsPublic()) {
+				activity.add(message);
+			}
 		}
 		Collections.sort(activity, Collections.reverseOrder());
 		return activity;

--- a/src/main/java/codeu/controller/ActivityfeedServlet.java
+++ b/src/main/java/codeu/controller/ActivityfeedServlet.java
@@ -68,6 +68,7 @@ public class ActivityfeedServlet extends HttpServlet{
 		for (Conversation convo : conversations) {
 			User owner = userStore.getUser(convo.getOwnerId());
 			convo.setDisplayText(owner.getName() + " created conversation: " + convo.getTitle());
+			// Only show activity about this convo if it is public or the logged-in user is a member
 			if (convo.getIsPublic()) {
 				activity.add(convo);
 			} else if ((username != null) && 
@@ -79,6 +80,7 @@ public class ActivityfeedServlet extends HttpServlet{
 			User author = userStore.getUser(message.getAuthorId());
 			Conversation conversation = conversationStore.getConversationWithID(message.getConversationId());
 			message.setDisplayText(author.getName() + " sent message: \"" + message.getContent() + "\"" + " to conversation: " + conversation.getTitle());
+			//only show messages to public conversations, or private ones where user is a member
 			if (conversation.getIsPublic()) {
 				activity.add(message);
 			} else if ((username != null) && 

--- a/src/main/webapp/WEB-INF/view/activityfeed.jsp
+++ b/src/main/webapp/WEB-INF/view/activityfeed.jsp
@@ -47,8 +47,6 @@
 
     <h1>Activity Feed</h1>
 
-	<p> This is the activity feed</p>
-
 	<%
     List<Activity> activity =
       (List<Activity>) request.getAttribute("activity");

--- a/src/test/java/codeu/controller/ActivityfeedServletTest.java
+++ b/src/test/java/codeu/controller/ActivityfeedServletTest.java
@@ -10,6 +10,7 @@ import javax.servlet.RequestDispatcher;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -33,12 +34,16 @@ public class ActivityfeedServletTest {
 	  private UserStore mockUserStore;
 	  private ConversationStore mockConversationStore;
 	  private MessageStore mockMessageStore;
+	  private HttpSession mockSession;
 	  
 	  @Before
 	  public void setup() {
 	    activityfeedServlet = new ActivityfeedServlet();
 	    
 	    mockRequest = Mockito.mock(HttpServletRequest.class);
+	    mockSession = Mockito.mock(HttpSession.class);
+	    Mockito.when(mockRequest.getSession()).thenReturn(mockSession);
+	    
 	    mockResponse = Mockito.mock(HttpServletResponse.class);
 	    mockRequestDispatcher = Mockito.mock(RequestDispatcher.class);
 	    Mockito.when(mockRequest.getRequestDispatcher("/WEB-INF/view/activityfeed.jsp"))
@@ -56,17 +61,18 @@ public class ActivityfeedServletTest {
 	  }
 
 	  @Test
-	  public void testDoGet() throws IOException, ServletException {
-		List<User> fakeUserList = new ArrayList<>();
-		List<Conversation> fakeConversationList = new ArrayList<>();
-		List<Message> fakeMessageList = new ArrayList<>();
+	  public void testDoGet_NoUser() throws IOException, ServletException {
+		List<User> fakeUserList = new ArrayList<User>();
+		List<Conversation> fakeConversationList = new ArrayList<Conversation>();
+		List<Message> fakeMessageList = new ArrayList<Message>();
 
 		User user1 = new User(UUID.randomUUID(), "test_name", "password", Instant.EPOCH, "about me");
-		Conversation conversation1 = new Conversation(UUID.randomUUID(), user1.getId(), "test_name", Instant.EPOCH.plusSeconds(1), true);
+		Conversation conversation1 = new Conversation(UUID.randomUUID(), user1.getId(), "test_name", Instant.EPOCH.plusSeconds(1), false);
 		Message message1 = new Message(UUID.randomUUID(), conversation1.getId(), user1.getId(), "test_message", Instant.EPOCH.plusSeconds(2));
 		User user2 = new User(UUID.randomUUID(), "test_name2", "password2", Instant.EPOCH.plusSeconds(3), "about me 2");
 		Conversation conversation2 = new Conversation(UUID.randomUUID(), user2.getId(), "test_name2", Instant.EPOCH.plusSeconds(4), true);
 		Message message2 = new Message(UUID.randomUUID(), conversation2.getId(), user2.getId(), "test_message2", Instant.EPOCH.plusSeconds(5));
+	
 
 		fakeUserList.add(user1);
 		fakeUserList.add(user2);
@@ -75,8 +81,16 @@ public class ActivityfeedServletTest {
 		fakeMessageList.add(message1);
 		fakeMessageList.add(message2);
 		
+		List<UUID> memberList = new ArrayList<UUID>();
+		memberList.add(user1.getId());
+		conversation1.setMembers(memberList);
+		List<UUID> conversationList = new ArrayList<UUID>();
+		conversationList.add(conversation1.getId());
+		user1.setConversations(conversationList);
+		
+		Mockito.when(mockSession.getAttribute("user")).thenReturn(null);
 	    Mockito.when(mockUserStore.getAllUsers()).thenReturn(fakeUserList);
-	    Mockito.when(mockConversationStore.getAllPublicConversations()).thenReturn(fakeConversationList);
+	    Mockito.when(mockConversationStore.getAllConversations()).thenReturn(fakeConversationList);
 	    Mockito.when(mockMessageStore.getAllMessages()).thenReturn(fakeMessageList);
 	    
 	    Mockito.when(mockUserStore.getUser(user1.getId())).thenReturn(user1);
@@ -91,12 +105,65 @@ public class ActivityfeedServletTest {
 	    orderedList.add(message2);
 	    orderedList.add(conversation2);
 	    orderedList.add(user2);
-	    orderedList.add(message1);
-	    orderedList.add(conversation1);
 	    orderedList.add(user1);
 
 	    Mockito.verify(mockRequest).setAttribute("activity", orderedList);
 	    Mockito.verify(mockRequestDispatcher).forward(mockRequest, mockResponse);
+	  }
+	  
+	  @Test 
+	  public void testDoGet_withUser() throws IOException, ServletException {
+		  	List<User> fakeUserList = new ArrayList<>();
+			List<Conversation> fakeConversationList = new ArrayList<>();
+			List<Message> fakeMessageList = new ArrayList<>();
+
+			User user1 = new User(UUID.randomUUID(), "test_name", "password", Instant.EPOCH, "about me");
+			Conversation conversation1 = new Conversation(UUID.randomUUID(), user1.getId(), "test_name", Instant.EPOCH.plusSeconds(1), false);
+			Message message1 = new Message(UUID.randomUUID(), conversation1.getId(), user1.getId(), "test_message", Instant.EPOCH.plusSeconds(2));
+			User user2 = new User(UUID.randomUUID(), "test_name2", "password2", Instant.EPOCH.plusSeconds(3), "about me 2");
+			Conversation conversation2 = new Conversation(UUID.randomUUID(), user2.getId(), "test_name2", Instant.EPOCH.plusSeconds(4), true);
+			Message message2 = new Message(UUID.randomUUID(), conversation2.getId(), user2.getId(), "test_message2", Instant.EPOCH.plusSeconds(5));
+
+			fakeUserList.add(user1);
+			fakeUserList.add(user2);
+			fakeConversationList.add(conversation1);
+			fakeConversationList.add(conversation2);
+			fakeMessageList.add(message1);
+			fakeMessageList.add(message2);
+			
+			List<UUID> memberList = new ArrayList<UUID>();
+			memberList.add(user1.getId());
+			conversation1.setMembers(memberList);
+			List<UUID> conversationList = new ArrayList<UUID>();
+			conversationList.add(conversation1.getId());
+			user1.setConversations(conversationList);
+			
+			Mockito.when(mockSession.getAttribute("user")).thenReturn("test_name");
+		    Mockito.when(mockUserStore.getUser("test_name")).thenReturn(user1);
+			
+		    Mockito.when(mockUserStore.getAllUsers()).thenReturn(fakeUserList);
+		    Mockito.when(mockConversationStore.getAllConversations()).thenReturn(fakeConversationList);
+		    Mockito.when(mockMessageStore.getAllMessages()).thenReturn(fakeMessageList);
+		    
+		    Mockito.when(mockUserStore.getUser(user1.getId())).thenReturn(user1);
+		    Mockito.when(mockUserStore.getUser(user2.getId())).thenReturn(user2);
+		    Mockito.when(mockConversationStore.getConversationWithID(conversation1.getId())).thenReturn(conversation1);
+		    Mockito.when(mockConversationStore.getConversationWithID(conversation2.getId())).thenReturn(conversation2);
+		    
+		    activityfeedServlet.doGet(mockRequest, mockResponse);
+		    
+		    // this creates the list in reverse order, which is how it should be sent by the servlet
+		    List<Activity> orderedList = new ArrayList<>();
+		    orderedList.add(message2);
+		    orderedList.add(conversation2);
+		    orderedList.add(user2);
+		    orderedList.add(message1);
+		    orderedList.add(conversation1);
+		    orderedList.add(user1);
+
+		    Mockito.verify(mockRequest).setAttribute("activity", orderedList);
+		    Mockito.verify(mockRequestDispatcher).forward(mockRequest, mockResponse);
+
 	  }
 	  
 }

--- a/src/test/java/codeu/controller/ActivityfeedServletTest.java
+++ b/src/test/java/codeu/controller/ActivityfeedServletTest.java
@@ -76,7 +76,7 @@ public class ActivityfeedServletTest {
 		fakeMessageList.add(message2);
 		
 	    Mockito.when(mockUserStore.getAllUsers()).thenReturn(fakeUserList);
-	    Mockito.when(mockConversationStore.getAllConversations()).thenReturn(fakeConversationList);
+	    Mockito.when(mockConversationStore.getAllPublicConversations()).thenReturn(fakeConversationList);
 	    Mockito.when(mockMessageStore.getAllMessages()).thenReturn(fakeMessageList);
 	    
 	    Mockito.when(mockUserStore.getUser(user1.getId())).thenReturn(user1);

--- a/src/test/java/codeu/controller/ActivityfeedServletTest.java
+++ b/src/test/java/codeu/controller/ActivityfeedServletTest.java
@@ -100,7 +100,8 @@ public class ActivityfeedServletTest {
 	    
 	    activityfeedServlet.doGet(mockRequest, mockResponse);
 	    
-	    // this creates the list in reverse order, which is how it should be sent by the servlet
+	    //Conversation1 is private and there is no user logged in, so it should not appear on 
+	    // the activity feed, and neither should the message to that conversation
 	    List<Activity> orderedList = new ArrayList<>();
 	    orderedList.add(message2);
 	    orderedList.add(conversation2);
@@ -138,6 +139,8 @@ public class ActivityfeedServletTest {
 			conversationList.add(conversation1.getId());
 			user1.setConversations(conversationList);
 			
+			//user1 is logged in, and they are a member of private conversation1,
+			// so they can see it in the activity feed
 			Mockito.when(mockSession.getAttribute("user")).thenReturn("test_name");
 		    Mockito.when(mockUserStore.getUser("test_name")).thenReturn(user1);
 			


### PR DESCRIPTION
I altered the activity feed so that it only shows activity from public conversations or private conversations that the logged-in user is a member of. This is similar to what I changed in the conversation page. 