### PR TITLE
Summer Open Privacy

### DIFF
--- a/src/main/java/codeu/controller/ChatServlet.java
+++ b/src/main/java/codeu/controller/ChatServlet.java
@@ -112,10 +112,11 @@ public class ChatServlet extends HttpServlet {
     }
     
     String username = (String) request.getSession().getAttribute("user");
-    //If the user is not a member of the private conversation, the conversation shouldn't appear
+    //If the user is not a member of the private conversation, the conversation shouldn't appear 
     if (!conversation.getIsPublic()) {
     	if (username == null ||  !members.contains(userStore.getUser(username).getId())) {
     		response.sendRedirect("/conversations");
+    		return;
     	}
     }
     

--- a/src/main/java/codeu/controller/ChatServlet.java
+++ b/src/main/java/codeu/controller/ChatServlet.java
@@ -111,6 +111,14 @@ public class ChatServlet extends HttpServlet {
     	userList.add(userStore.getUser(member).getName());
     }
     
+    String username = (String) request.getSession().getAttribute("user");
+    //If the user is not a member of the private conversation, the conversation shouldn't appear
+    if (!conversation.getIsPublic()) {
+    	if (username == null ||  !members.contains(userStore.getUser(username).getId())) {
+    		response.sendRedirect("/conversations");
+    	}
+    }
+    
     List<Message> messages = messageStore.getMessagesInConversation(conversationId);
 
     request.setAttribute("conversation", conversation);

--- a/src/main/java/codeu/controller/ProfileServlet.java
+++ b/src/main/java/codeu/controller/ProfileServlet.java
@@ -24,6 +24,14 @@ public class ProfileServlet extends HttpServlet {
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response)
       throws IOException, ServletException {
+	    String requestUrl = request.getRequestURI();
+	    String usersProfile = requestUrl.substring("/profile/".length());
+	    User user = userStore.getUser(usersProfile);
+	    if (user==null) {
+	        response.sendRedirect("/");
+	        return;
+	    }
+	    request.setAttribute("usersProfile", user);
         request.getRequestDispatcher("/WEB-INF/view/profile.jsp").forward(request, response);
   }
 

--- a/src/main/webapp/WEB-INF/view/profile.jsp
+++ b/src/main/webapp/WEB-INF/view/profile.jsp
@@ -29,15 +29,18 @@
     </nav>
 
     <div id="container">
-      <%if(request.getSession().getAttribute("user") != null) { %>
-        <h1><%=request.getSession().getAttribute("user")%>'s Profile Page</h1>
+      <% User user = (User)request.getAttribute("usersProfile");
+      if( user != null) { %>
+        <h1><%=user.getName()%>'s Profile Page</h1>
         <hr/>
         <form action="/profile" method="POST">
           <h2> About Me </h2>
-            <p style="width:800px"><%=UserStore.getInstance().getUser((String)request.getSession().getAttribute("user")).getAboutMe() %></p>
+            <p style="width:800px"><%=user.getAboutMe() %></p>
+          <% if (user.getName().equals(request.getSession().getAttribute("user"))) {%>
           <h3> Edit your About Me(only you can see this)</h2>
           <textarea name="aboutMe" rows="5" cols="112"></textarea>
           <button type="submit">Submit</button>
+          <% } %>
         </form>
       <%} %>
     </div>

--- a/src/test/java/codeu/controller/ChatServletTest.java
+++ b/src/test/java/codeu/controller/ChatServletTest.java
@@ -74,7 +74,7 @@ public class ChatServletTest {
   }
 
   @Test
-  public void testDoGet() throws IOException, ServletException {
+  public void testDoGet_publicConvo() throws IOException, ServletException {
     Mockito.when(mockRequest.getRequestURI()).thenReturn("/chat/test_conversation");
 
     UUID fakeConversationId = UUID.randomUUID();
@@ -108,6 +108,66 @@ public class ChatServletTest {
     Mockito.verify(mockRequest).setAttribute("conversation", fakeConversation);
     Mockito.verify(mockRequest).setAttribute("messages", fakeMessageList);
     Mockito.verify(mockRequest).setAttribute("member", fakeUserList);
+    Mockito.verify(mockRequestDispatcher).forward(mockRequest, mockResponse);
+  }
+  
+  @Test
+  public void testDoGet_privateConvo_NoUser() throws IOException, ServletException {
+	Mockito.when(mockRequest.getRequestURI()).thenReturn("/chat/private_conversation");
+    Mockito.when(mockSession.getAttribute("user")).thenReturn(null);
+    
+    UUID privateConversationId = UUID.randomUUID();
+    Conversation privateConversation =
+        new Conversation(privateConversationId, UUID.randomUUID(), "private_conversation", Instant.now(), false);
+    Mockito.when(mockConversationStore.getConversationWithTitle("private_conversation"))
+        .thenReturn(privateConversation);
+
+    chatServlet.doGet(mockRequest, mockResponse);
+    Mockito.verify(mockResponse).sendRedirect("/conversations");
+  }
+  
+  @Test
+  public void testDoGet_privateConvo_UserIsMember() throws IOException, ServletException {
+	Mockito.when(mockRequest.getRequestURI()).thenReturn("/chat/private_conversation");
+    Mockito.when(mockSession.getAttribute("user")).thenReturn("test_username");
+    
+    User test_user =
+            new User(
+                UUID.randomUUID(),
+                "test username",
+                "$2a$10$.e.4EEfngEXmxAO085XnYOmDntkqod0C384jOR9oagwxMnPNHaGLa",
+                Instant.now(), "test_aboutMe");
+    List<UUID> members = new ArrayList<>();
+    List<String> memberNames = new ArrayList<>();
+    members.add(test_user.getId());
+    memberNames.add(test_user.getName());
+    
+    UUID privateConversationId = UUID.randomUUID();
+    Conversation privateConversation =
+        new Conversation(privateConversationId, UUID.randomUUID(), "private_conversation", Instant.now(), false);
+    privateConversation.setMembers(members);
+    test_user.addConversation(privateConversation.getId());
+    Mockito.when(mockConversationStore.getConversationWithTitle("private_conversation"))
+        .thenReturn(privateConversation);
+    Mockito.when(mockUserStore.getUser(test_user.getId())).thenReturn(test_user);
+    Mockito.when(mockUserStore.getUser("test_username")).thenReturn(test_user);
+    
+    List<Message> fakeMessageList = new ArrayList<>();
+    fakeMessageList.add(
+        new Message(
+            UUID.randomUUID(),
+            privateConversationId,
+            UUID.randomUUID(),
+            "test message",
+            Instant.now()));
+    Mockito.when(mockMessageStore.getMessagesInConversation(privateConversationId))
+        .thenReturn(fakeMessageList);
+
+
+    chatServlet.doGet(mockRequest, mockResponse);
+    Mockito.verify(mockRequest).setAttribute("conversation", privateConversation);
+    Mockito.verify(mockRequest).setAttribute("messages", fakeMessageList);
+    Mockito.verify(mockRequest).setAttribute("member", memberNames);
     Mockito.verify(mockRequestDispatcher).forward(mockRequest, mockResponse);
   }
 

--- a/src/test/java/codeu/controller/ProfileServletTest.java
+++ b/src/test/java/codeu/controller/ProfileServletTest.java
@@ -2,6 +2,8 @@ package codeu.controller;
 
 import codeu.model.data.User;
 import codeu.model.store.basic.UserStore;
+import junit.framework.Assert;
+
 import java.io.IOException;
 import java.time.Instant;
 import java.util.UUID;
@@ -40,8 +42,20 @@ public class ProfileServletTest {
 
   @Test
   public void testDoGet() throws IOException, ServletException {
+	Mockito.when(mockRequest.getRequestURI()).thenReturn("/profile/test_username");
+	User test_user = new User(UUID.randomUUID(), "test_username", "$2a$10$bBiLUAVmUFK6Iwg5r", Instant.now(), "about me");
+	Mockito.when(mockUserStore.getUser("test_username")).thenReturn(test_user);
     profileServlet.doGet(mockRequest, mockResponse);
+    Mockito.verify(mockRequest).setAttribute("usersProfile", test_user);
     Mockito.verify(mockRequestDispatcher).forward(mockRequest, mockResponse);
+  }
+  
+  @Test
+  public void testDoGet_invalidUser() throws IOException, ServletException {
+	Mockito.when(mockRequest.getRequestURI()).thenReturn("/profile/test_username");
+	Mockito.when(mockUserStore.getUser("test_username")).thenReturn(null);
+	profileServlet.doGet(mockRequest, mockResponse);
+	Mockito.verify(mockResponse).sendRedirect("/");
   }
 
   @Test


### PR DESCRIPTION
I added another privacy check to Chat so that if the chat is private and no one is logged in, or the logged-in user is not a member of the conversation, the page redirects. This is so that someone can't just type the url of a private conversation to get to it. I also edited ProfileServlet so that going to a different user's url will show their about me but not the edit textbox.